### PR TITLE
fix(processor): fields with override do not work

### DIFF
--- a/example/src/main/kotlin/com/github/materiiapps/partial/example/Data.kt
+++ b/example/src/main/kotlin/com/github/materiiapps/partial/example/Data.kt
@@ -12,6 +12,10 @@ annotation class SampleAnnotation(
     val c: Array<KClass<*>>,
 )
 
+interface Thing {
+    val w: Int
+}
+
 @Partialize(
     children = [
         AgedUser::class,
@@ -34,8 +38,10 @@ data class AgedUser(
     @SampleAnnotation(b = AgedUser::class, c = [])
     val age: Int,
 
-    override val private: Boolean = false  // overridden skipped property (needs default value)
-) : GenericUser
+    override val private: Boolean = false  // overridden skipped property (needs default value),
+    
+    override val w: Int
+) : GenericUser, Thing
 
 @Partialize
 data class UnknownUser(
@@ -50,7 +56,7 @@ data class UnknownUser(
 ) : GenericUser
 
 fun main() {
-    val full = AgedUser(name = "Gregory", age = 14)
+    val full = AgedUser(name = "Gregory", age = 14, w = 76)
     val partial = AgedUserPartial(age = Partial.Value(15))
     val merged = full.merge(partial)
     println(merged)

--- a/example/src/main/kotlin/com/github/materiiapps/partial/example/Data.kt
+++ b/example/src/main/kotlin/com/github/materiiapps/partial/example/Data.kt
@@ -38,9 +38,9 @@ data class AgedUser(
     @SampleAnnotation(b = AgedUser::class, c = [])
     val age: Int,
 
-    override val private: Boolean = false  // overridden skipped property (needs default value),
+    override val private: Boolean = false,  // overridden skipped property (needs default value),
     
-    override val w: Int
+    override val w: Int // should not put override on partial
 ) : GenericUser, Thing
 
 @Partialize

--- a/partial-ksp/src/main/kotlin/com/github/materiiapps/partial/ksp/PartialProcessor.kt
+++ b/partial-ksp/src/main/kotlin/com/github/materiiapps/partial/ksp/PartialProcessor.kt
@@ -160,7 +160,7 @@ internal class PartialProcessor(
                         .builder(name, type)
                         .addAnnotations(paramAnnotations)
                         .initializer(name)
-                        .addModifiers(property.modifiers.mapNotNull { it.toKModifier() }.filterNot { it == KModifier.OVERRIDE && !((it.parentDeclaration as? KSClassDeclaration)?.let(partialSuperclasses::contains) ?: false) })
+                        .addModifiers(property.modifiers.mapNotNull { it.toKModifier() }.filterNot { it == KModifier.OVERRIDE && !((propery.findOverriddee()?.parentDeclaration as? KSClassDeclaration)?.let(partialSuperclasses::contains) ?: false) })
                         .build()
                 )
                 parameters.add(

--- a/partial-ksp/src/main/kotlin/com/github/materiiapps/partial/ksp/PartialProcessor.kt
+++ b/partial-ksp/src/main/kotlin/com/github/materiiapps/partial/ksp/PartialProcessor.kt
@@ -160,7 +160,7 @@ internal class PartialProcessor(
                         .builder(name, type)
                         .addAnnotations(paramAnnotations)
                         .initializer(name)
-                        .addModifiers(property.modifiers.mapNotNull { it.toKModifier() }.filterNot { it == KModifier.OVERRIDE && !((property.findOverriddee()?.parentDeclaration as? KSClassDeclaration)?.let(partialSuperclasses::contains) ?: false) })
+                        .addModifiers(property.modifiers.mapNotNull { it.toKModifier() }.filterNot { it == KModifier.OVERRIDE && !((property.findOverridee()?.parentDeclaration as? KSClassDeclaration)?.let(partialSuperclasses::contains) ?: false) })
                         .build()
                 )
                 parameters.add(

--- a/partial-ksp/src/main/kotlin/com/github/materiiapps/partial/ksp/PartialProcessor.kt
+++ b/partial-ksp/src/main/kotlin/com/github/materiiapps/partial/ksp/PartialProcessor.kt
@@ -160,7 +160,12 @@ internal class PartialProcessor(
                         .builder(name, type)
                         .addAnnotations(paramAnnotations)
                         .initializer(name)
-                        .addModifiers(property.modifiers.mapNotNull { it.toKModifier() }.filterNot { it == KModifier.OVERRIDE && !((property.findOverridee()?.parentDeclaration as? KSClassDeclaration)?.let(partialSuperclasses::contains) ?: false) })
+                        .addModifiers(property.modifiers
+                            .mapNotNull { it.toKModifier() }
+                            .filterNot { it == KModifier.OVERRIDE && 
+                                    !((property.findOverridee()?.parentDeclaration as? KSClassDeclaration)
+                                        ?.let(partialSuperclasses::contains) ?: false) }
+                        )
                         .build()
                 )
                 parameters.add(

--- a/partial-ksp/src/main/kotlin/com/github/materiiapps/partial/ksp/PartialProcessor.kt
+++ b/partial-ksp/src/main/kotlin/com/github/materiiapps/partial/ksp/PartialProcessor.kt
@@ -160,7 +160,7 @@ internal class PartialProcessor(
                         .builder(name, type)
                         .addAnnotations(paramAnnotations)
                         .initializer(name)
-                        .addModifiers(property.modifiers.mapNotNull { it.toKModifier() }.filterNot { it == KModifier.OVERRIDE && !((propery.findOverriddee()?.parentDeclaration as? KSClassDeclaration)?.let(partialSuperclasses::contains) ?: false) })
+                        .addModifiers(property.modifiers.mapNotNull { it.toKModifier() }.filterNot { it == KModifier.OVERRIDE && !((property.findOverriddee()?.parentDeclaration as? KSClassDeclaration)?.let(partialSuperclasses::contains) ?: false) })
                         .build()
                 )
                 parameters.add(

--- a/partial-ksp/src/main/kotlin/com/github/materiiapps/partial/ksp/PartialProcessor.kt
+++ b/partial-ksp/src/main/kotlin/com/github/materiiapps/partial/ksp/PartialProcessor.kt
@@ -160,7 +160,7 @@ internal class PartialProcessor(
                         .builder(name, type)
                         .addAnnotations(paramAnnotations)
                         .initializer(name)
-                        .addModifiers(property.modifiers.mapNotNull { it.toKModifier() })
+                        .addModifiers(property.modifiers.mapNotNull { it.toKModifier() }.minus(KModifier.OVERRIDE))
                         .build()
                 )
                 parameters.add(

--- a/partial-ksp/src/main/kotlin/com/github/materiiapps/partial/ksp/PartialProcessor.kt
+++ b/partial-ksp/src/main/kotlin/com/github/materiiapps/partial/ksp/PartialProcessor.kt
@@ -160,7 +160,7 @@ internal class PartialProcessor(
                         .builder(name, type)
                         .addAnnotations(paramAnnotations)
                         .initializer(name)
-                        .addModifiers(property.modifiers.mapNotNull { it.toKModifier() }.minus(KModifier.OVERRIDE))
+                        .addModifiers(property.modifiers.mapNotNull { it.toKModifier() }.filterNot { it == KModifier.OVERRIDE && !((it.parentDeclaration as? KSClassDeclaration)?.let(partialSuperclasses::contains) ?: false) })
                         .build()
                 )
                 parameters.add(


### PR DESCRIPTION
This PR contains a fix for the processor to not add the override modifier to fields of PartialX classes

(sorry in advance for a lot of mistakes, it's because currently I'm unable to edit code except in browser from phone, where code completion is nonexistent and you see errors only in workflow runs)